### PR TITLE
Support older versions of git without `git remote get-url`

### DIFF
--- a/sourcegraph.py
+++ b/sourcegraph.py
@@ -25,7 +25,7 @@ def gitRemotes(repoDir):
 # gitRemoteURL returns the remote URL for the given remote name.
 # e.g. 'origin' -> 'git@github.com:foo/bar'
 def gitRemoteURL(repoDir, remoteName):
-	proc = subprocess.Popen(['git', 'remote', 'get-url', remoteName], stdout=subprocess.PIPE, cwd=repoDir, startupinfo=startupinfo)
+	proc = subprocess.Popen(['git', 'config', '--get', 'remote.{}.url'.format(remoteName)], stdout=subprocess.PIPE, cwd=repoDir, startupinfo=startupinfo)
 	return proc.stdout.read().decode('utf-8').rstrip()
 
 # gitDefaultRemoteURL returns the remote URL of the first Git remote found. An


### PR DESCRIPTION
It seems older versions of git (at least version 2.4.11) do not support `git remote get-url`; this incantation works instead.